### PR TITLE
Movement from conda to pip install with docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ COPY fresh /opt/kx/ml/fresh
 COPY util /opt/kx/ml/util
 COPY xval /opt/kx/ml/xval
 COPY clust /opt/kx/ml/clust
+COPY graph /opt/kx/ml/graph
 COPY timeseries /opt/kx/ml/timeseries
 COPY optimize /opt/kx/ml/optimize
 
@@ -35,13 +36,14 @@ RUN chown -R kx:kx /opt/kx/ml
 RUN mkdir /opt/kx/q/ml
 RUN find /opt/kx/ml -maxdepth 1 -type f -name '*.q' | xargs ln -s -t /opt/kx/q/ml \
         && ln -s -t /opt/kx/q/ml /opt/kx/ml/fresh /opt/kx/ml/utils /opt/kx/ml/xval /opt/kx/ml/clust \
-        /opt/kx/ml/timeseries /opt/kx/ml/optimize
+        /opt/kx/ml/graph /opt/kx/ml/timeseries /opt/kx/ml/optimize
 
 USER kx
 
 RUN . /opt/conda/etc/profile.d/conda.sh \
         && conda activate kx \
-        && conda install -c conda-forge --file /opt/kx/ml/requirements.txt \
+        && pip install pip==9.0.1 \
+        && pip install -r /opt/kx/ml/requirements.txt \
         && conda clean -y --all 
 
 USER root


### PR DESCRIPTION
conda install for docker image does not support for sobol-seq package, as such movement to pip install is supplied